### PR TITLE
dock:README編集

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ Smoker Bankは、自分が吸ったタバコの本数を簡単に記録できる
 - ユーザー情報の変更画面  
 
 ## 使用する技術スタック
-- 使用するフレームワーク（Ruby on Rails / 8.0.2.1 以上 8.1 未満）
+- 使用するフレームワーク（Ruby on Rails / 7.2.1）
 - データベース（PostgreSQL）
 - デプロイ先（Render）
-- 使用予定のGem（ransack / kaminari / Tailwind / line-bot-sdk-ruby / Devise / omniauth-google-oauth2）
+- 使用Gem（kaminari / Tailwind / Devise / omniauth-google-oauth2 / sendgrid-ruby）
+
+## アプリURL
+https://smoker-bank.onrender.com/
 
 ## 画面遷移図
 [画面遷移図（Figma）](https://www.figma.com/design/oS8wTW6u0WIxZXqUt9bmDp/smoker-bank?node-id=0-1&t=X7aWSsd2NaSFdeJh-1)


### PR DESCRIPTION
## 内容
LINE通知機能のキャッチアップを行ないましたが、
リマインド機能の実装を想定したところ、
無料プランだと一日200通までしか送信できないため、
リリース予定の機能から外しました。